### PR TITLE
Add an option to get the least up-to-date version of each packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-_build
+/_build
 .merlin
+*.install

--- a/lib-cudf/opam_0install_cudf.ml
+++ b/lib-cudf/opam_0install_cudf.ml
@@ -4,6 +4,7 @@ module Context = struct
   type t = {
     universe : Cudf.universe;
     constraints : (Cudf_types.pkgname * (Cudf_types.relop * Cudf_types.version)) list;
+    prefer_oldest : bool;
   }
 
   let load t pkg =
@@ -17,13 +18,19 @@ module Context = struct
         acc
     ) [] t.constraints
 
+  let version_compare t pkg1 pkg2 =
+    if t.prefer_oldest then
+      compare (pkg1.Cudf.version : int) pkg2.Cudf.version
+    else
+      compare (pkg2.Cudf.version : int) pkg1.Cudf.version
+
   let candidates t name =
     let user_constraints = user_restrictions t name in
     match Cudf.lookup_packages t.universe name with
     | [] ->
         [] (* Package not found *)
     | versions ->
-        List.fast_sort (fun pkg1 pkg2 -> compare (pkg2.Cudf.version : int) pkg1.Cudf.version) versions
+        List.fast_sort (version_compare t) versions (* Higher versions are preferred. *)
         |> List.map (fun pkg ->
           let rec check_constr = function
             | [] -> (pkg.Cudf.version, None)
@@ -65,8 +72,8 @@ type t = Context.t
 type selections = Solver.Output.t
 type diagnostics = Input.requirements   (* So we can run another solve *)
 
-let create ~constraints universe =
-  { Context.universe; constraints; }
+let create ?(prefer_oldest=false) ~constraints universe =
+  { Context.universe; constraints; prefer_oldest }
 
 let solve context pkgs =
   let req = requirements ~context pkgs in

--- a/lib-cudf/opam_0install_cudf.mli
+++ b/lib-cudf/opam_0install_cudf.mli
@@ -4,9 +4,17 @@ type selections
 
 type diagnostics
 
-val create : constraints:(Cudf_types.pkgname * (Cudf_types.relop * Cudf_types.version)) list -> Cudf.universe -> t
-(** [create ~constraints universe] is a solver that gets candidates from [universe], filtering them
-    using [constraints]. *)
+val create :
+  ?prefer_oldest:bool ->
+  constraints:(Cudf_types.pkgname * (Cudf_types.relop * Cudf_types.version)) list ->
+  Cudf.universe ->
+  t
+(** [create ~constraints universe] is a solver that gets candidates from [universe],
+    filtering them using [constraints].
+
+    @param prefer_oldest if [true] the solver is set to return the least
+    up-to-date version of each package, if a solution exists. This is [false] by
+    default. @before 0.4 the [prefer_oldest] parameter did not exist. *)
 
 val solve :
   t ->

--- a/lib/dir_context.mli
+++ b/lib/dir_context.mli
@@ -20,6 +20,7 @@ val std_env :
     variables, and [None] for anything else. *)
 
 val create :
+  ?prefer_oldest:bool ->
   ?test:OpamPackage.Name.Set.t ->
   ?pins:(OpamTypes.version * OpamFile.OPAM.t) OpamTypes.name_map ->
   constraints:OpamFormula.version_constraint OpamTypes.name_map ->
@@ -33,4 +34,7 @@ val create :
     @param test Packages for which we should include "with-test" dependencies.
     @param pins Packages in this map have only the given candidate version and opam file.
     @param env Maps opam variable names to values ({!std_env} may be useful here).
-               "version" and the [OpamPackageVar.predefined_depends_variables] are handled automatically. *)
+               "version" and the [OpamPackageVar.predefined_depends_variables] are handled automatically.
+    @param prefer_oldest if [true] the solver is set to return the least
+    up-to-date version of each package, if a solution exists. This is [false] by
+    default. @before 0.4 the [prefer_oldest] parameter did not exist. *)

--- a/lib/switch_context.ml
+++ b/lib/switch_context.ml
@@ -40,8 +40,7 @@ let candidates t name =
   let user_constraints = user_restrictions t name in
   match OpamPackage.Name.Map.find_opt name t.pkgs with
   | Some versions ->
-    OpamPackage.Version.Set.to_seq versions
-    |> List.of_seq
+    OpamPackage.Version.Set.elements versions
     |> sort_versions t       (* Higher versions are preferred. *)
     |> List.map (fun v ->
         match user_constraints with

--- a/lib/switch_context.ml
+++ b/lib/switch_context.ml
@@ -5,6 +5,7 @@ type t = {
   pkgs : OpamTypes.version_set OpamTypes.name_map;                    (* All available versions *)
   constraints : OpamFormula.version_constraint OpamTypes.name_map;    (* User-provided constraints *)
   test : OpamPackage.Name.Set.t;
+  prefer_oldest : bool;
 }
 
 let load t pkg =
@@ -29,13 +30,19 @@ let filter_deps t pkg f =
   |> OpamFilter.partial_filter_formula (env t pkg)
   |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev:false ~default:false
 
+let sort_versions t versions =
+  if t.prefer_oldest then
+    versions
+  else
+    List.rev versions
+
 let candidates t name =
   let user_constraints = user_restrictions t name in
   match OpamPackage.Name.Map.find_opt name t.pkgs with
   | Some versions ->
     OpamPackage.Version.Set.to_seq versions
     |> List.of_seq
-    |> List.rev       (* Higher versions are preferred. *)
+    |> sort_versions t       (* Higher versions are preferred. *)
     |> List.map (fun v ->
         match user_constraints with
         | Some test when not (OpamFormula.check_version_formula (OpamFormula.Atom test) v) ->
@@ -52,6 +59,6 @@ let candidates t name =
 let pp_rejection f = function
   | UserConstraint x -> Fmt.pf f "Rejected by user-specified constraint %s" (OpamFormula.string_of_atom x)
 
-let create ?(test=OpamPackage.Name.Set.empty) ~constraints st =
+let create ?(prefer_oldest=false) ?(test=OpamPackage.Name.Set.empty) ~constraints st =
   let pkgs = Lazy.force st.OpamStateTypes.available_packages |> OpamPackage.to_map in
-  { st; pkgs; constraints; test }
+  { st; pkgs; constraints; test; prefer_oldest }

--- a/lib/switch_context.mli
+++ b/lib/switch_context.mli
@@ -1,10 +1,16 @@
 include S.CONTEXT
 
 val create :
+  ?prefer_oldest:bool ->
   ?test:OpamPackage.Name.Set.t ->
   constraints:OpamFormula.version_constraint OpamTypes.name_map ->
   OpamStateTypes.unlocked OpamStateTypes.switch_state ->
   t
 (** [create ~constraints switch] is a solver that gets candidates from [switch], filtering them
     using [constraints].
-    @param test Packages for which we should include "with-test" dependencies. *)
+
+    @param test Packages for which we should include "with-test" dependencies.
+
+    @param prefer_oldest if [true] the solver is set to return the least
+    up-to-date version of each package, if a solution exists. This is [false] by
+    default. @before 0.4 the [prefer_oldest] parameter did not exist. *)


### PR DESCRIPTION
In a CI context it is sometimes useful to test the lower-bound constraints of dependencies, to ensure no state exist in which the package would fail to compile.
By reversing the order of candidate versions we can get just that.

If you have a better idea than `least_up_to_date / least-up-to-date` for the name of such variable, feel free to propose something else.