### PR TITLE
opam-0install-cudf: Remove unused and unnecessary dependencies for easier integration with opam

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -52,8 +52,6 @@ This package uses 0install's solver algorithm with opam packages using
 the CUDF interface.
 ")
  (depends
-  fmt
-  cmdliner
   cudf
   (ocaml (>= 4.08.0))
   0install-solver))

--- a/lib-cudf/dune
+++ b/lib-cudf/dune
@@ -1,4 +1,4 @@
 (library
  (name opam_0install_cudf)
  (public_name opam-0install-cudf)
- (libraries cudf 0install-solver fmt))
+ (libraries cudf 0install-solver))

--- a/lib-cudf/opam_0install_cudf.ml
+++ b/lib-cudf/opam_0install_cudf.ml
@@ -50,7 +50,7 @@ module Context = struct
     | Some (`Lt, v) -> "<"^string_of_int v
 
   let pp_rejection f = function
-    | UserConstraint (name, c) -> Fmt.pf f "Rejected by user-specified constraint %s%s" name (print_constr c)
+    | UserConstraint (name, c) -> Format.fprintf f "Rejected by user-specified constraint %s%s" name (print_constr c)
 end
 
 module Input = Model.Make(Context)

--- a/lib-cudf/s.ml
+++ b/lib-cudf/s.ml
@@ -5,7 +5,7 @@ module type CONTEXT = sig
   (** A reason why a package can't be used as input to the solver. e.g. it is
       for a different platform, or conflicts with a user-provided constraint. *)
 
-  val pp_rejection : rejection Fmt.t
+  val pp_rejection : Format.formatter -> rejection -> unit
 
   val candidates : t -> Cudf_types.pkgname -> (Cudf_types.version * (Cudf.package, rejection) result) list
   (** [candidates t name] is the list of available versions of [name], in order

--- a/opam-0install-cudf.opam
+++ b/opam-0install-cudf.opam
@@ -21,8 +21,6 @@ doc: "https://ocaml-opam.github.io/opam-0install-solver/"
 bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
 depends: [
   "dune" {>= "2.0"}
-  "fmt"
-  "cmdliner"
   "cudf"
   "ocaml" {>= "4.08.0"}
   "0install-solver"


### PR DESCRIPTION
`cmdliner` was unused and `fmt` is nice but `Format` can be used instead and makes it easier to ship it with opam itself