### PR TITLE
Upgrade to opam 2.1 and dune 2.7

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -9,7 +9,7 @@ let select verbose with_test prefer_oldest = function
     let root = OpamStateConfig.opamroot () in
     OpamFormatConfig.init ();
     ignore (OpamStateConfig.load_defaults root);
-    OpamStd.Config.init ();
+    OpamCoreConfig.init ();
     OpamStateConfig.init ();
     OpamGlobalState.with_ `Lock_none @@ fun gt ->
     OpamSwitchState.with_ `Lock_none gt @@ fun st ->

--- a/dune-project
+++ b/dune-project
@@ -9,6 +9,7 @@
 (authors "talex5@gmail.com")
 (maintainers "talex5@gmail.com")
 (documentation "https://ocaml-opam.github.io/opam-0install-solver/")
+(license ISC)
 
 (package
  (name opam-0install)

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 2.7)
 (name opam-0install)
 (version 0.4.1)
 (formatting disabled)
@@ -27,7 +27,7 @@ This package uses 0install's solver algorithm with opam packages.
  (depends
   fmt
   cmdliner
-  opam-state
+  (opam-state (>= 2.1.0~rc))
   (ocaml (>= 4.08.0))
   0install-solver
   (opam-file-format (>= 2.1.1))

--- a/opam-0install-cudf.opam
+++ b/opam-0install-cudf.opam
@@ -16,6 +16,7 @@ the CUDF interface.
 """
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
+license: "ISC"
 homepage: "https://github.com/ocaml-opam/opam-0install-solver"
 doc: "https://ocaml-opam.github.io/opam-0install-solver/"
 bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"

--- a/opam-0install-cudf.opam
+++ b/opam-0install-cudf.opam
@@ -20,13 +20,14 @@ homepage: "https://github.com/ocaml-opam/opam-0install-solver"
 doc: "https://ocaml-opam.github.io/opam-0install-solver/"
 bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.7"}
   "cudf"
   "ocaml" {>= "4.08.0"}
   "0install-solver"
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/opam-0install.opam
+++ b/opam-0install.opam
@@ -15,6 +15,7 @@ This package uses 0install's solver algorithm with opam packages.
 """
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
+license: "ISC"
 homepage: "https://github.com/ocaml-opam/opam-0install-solver"
 doc: "https://ocaml-opam.github.io/opam-0install-solver/"
 bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"

--- a/opam-0install.opam
+++ b/opam-0install.opam
@@ -19,10 +19,10 @@ homepage: "https://github.com/ocaml-opam/opam-0install-solver"
 doc: "https://ocaml-opam.github.io/opam-0install-solver/"
 bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.7"}
   "fmt"
   "cmdliner"
-  "opam-state"
+  "opam-state" {>= "2.1.0~rc"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-file-format" {>= "2.1.1"}
@@ -30,9 +30,10 @@ depends: [
   "opam-solver" {with-test}
   "astring" {with-test}
   "alcotest" {with-test}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/test/test.ml
+++ b/test/test.ml
@@ -31,7 +31,7 @@ let select_opam st spec =
   match OpamSolution.resolve st Install ~orphans:OpamPackage.Set.empty ~requested:names request with
   | Success s -> Ok (OpamSolver.all_packages s)
   | Conflicts c -> Error (lazy (
-      OpamCudf.string_of_conflict st.packages (OpamSwitchState.unavailable_reason st) c
+      OpamCudf.string_of_conflicts st.packages (OpamSwitchState.unavailable_reason st) c
       |> String.trim
     ))
 
@@ -149,7 +149,7 @@ let () =
   let root = OpamStateConfig.opamroot () in
   OpamFormatConfig.init ();
   ignore (OpamStateConfig.load_defaults root);
-  OpamStd.Config.init ();
+  OpamCoreConfig.init ();
   OpamStateConfig.init ();
   OpamClientConfig.opam_init ();
   OpamGlobalState.with_ `Lock_none @@ fun gt ->


### PR DESCRIPTION
https://github.com/ocaml/opam/commit/a7c03d302bf1ccdf77f5ba975a0c5f0eb80b59c4 moved `OpamStd.Config` to `OpamCoreConfig` and thus broke opam-0install.

This PR also upgrades to dune 2.7 so the opam file generation includes the `odoc` and `dune subst {dev}` fix