### PR TITLE
Expose diagnostics rolemap in Solver

### DIFF
--- a/lib/model.ml
+++ b/lib/model.ml
@@ -269,4 +269,10 @@ module Make (Context : S.CONTEXT) = struct
     | Reject pkg -> Some pkg
     | VirtualImpl _ -> None
     | Dummy -> None
+
+  let package_name = function
+    | Real {name; _} -> Some name
+    | Virtual _ -> None
+
+  let formula { kind; expr } = (kind, expr)
 end

--- a/lib/model.mli
+++ b/lib/model.mli
@@ -41,5 +41,5 @@ module Make (Context : S.CONTEXT) : sig
   val formula : restriction -> [`Ensure | `Prevent] * OpamFormula.version_formula
   (** [formula restriction] returns the version formula represented by this
       restriction along with its negation status: [(`Prevent, formula)] roughly
-      means [not formula]. *) 
+      means [not formula]. *)
 end

--- a/lib/model.mli
+++ b/lib/model.mli
@@ -33,4 +33,13 @@ module Make (Context : S.CONTEXT) : sig
       on [depends]. This is used if the user requests multiple packages on the
       command line - each requested package becomes a dependency of the virtual
       implementation. *)
+
+  val package_name : Role.t -> OpamPackage.Name.t option
+  (** [package_name role] is the Opam package name for [role], if any.
+      Return [None] on virtual roles. *)
+
+  val formula : restriction -> [`Ensure | `Prevent] * OpamFormula.version_formula
+  (** [formula restriction] returns the version formula represented by this
+      restriction along with its negation status: [(`Prevent, formula)] roughly
+      means [not formula]. *) 
 end

--- a/lib/model.mli
+++ b/lib/model.mli
@@ -15,7 +15,7 @@
     implementation. *)
 
 module Make (Context : S.CONTEXT) : sig
-  include Zeroinstall_solver.S.SOLVER_INPUT
+  include Zeroinstall_solver.S.SOLVER_INPUT with type rejection = Context.rejection
 
   val role : Context.t -> OpamPackage.Name.t -> Role.t
 

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -1,6 +1,10 @@
 module Make(Context : S.CONTEXT) = struct
   module Input = Model.Make(Context)
 
+  let version = Input.version
+  let package_name = Input.package_name
+  let formula = Input.formula
+
   let requirements ~context pkgs =
     let role =
       match pkgs with

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -49,10 +49,13 @@ module Make(Context : S.CONTEXT) = struct
     Fmt.pf f "Selected: @[<hov>%a@]@,%a" (Fmt.(list ~sep:sp) pp_short) short
       (Fmt.(list ~sep:cut) pp_item) long
 
-  let diagnostics ?(verbose=false) req =
+  let diagnostics_rolemap req =
     Solver.do_solve req ~closest_match:true
     |> Option.get
     |> Diagnostics.of_result
+
+  let diagnostics ?(verbose=false) req =
+    diagnostics_rolemap req
     |> Fmt.strf "Can't find all required versions.@\n@[<v0>%a@]" (pp_rolemap ~verbose)
 
   let packages_of_result sels =

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,9 +1,7 @@
 module Make (C : S.CONTEXT) : sig
   include S.SOLVER with type t = C.t
 
-  module Input : sig
-    include Zeroinstall_solver.S.SOLVER_INPUT with type rejection = C.rejection
-  end
+  module Input : Zeroinstall_solver.S.SOLVER_INPUT with type rejection = C.rejection
 
   module Solver : sig
     module Output : Zeroinstall_solver.S.SOLVER_RESULT with module Input = Input
@@ -13,5 +11,8 @@ module Make (C : S.CONTEXT) : sig
     include module type of Zeroinstall_solver.Diagnostics(Solver.Output)
   end
 
+  val version : Input.impl -> OpamPackage.t option
+  val package_name : Input.Role.t -> OpamPackage.Name.t option
+  val formula : Input.restriction -> [`Ensure | `Prevent] * OpamFormula.version_formula
   val diagnostics_rolemap : diagnostics -> Diagnostics.t
 end

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,1 +1,17 @@
-module Make (C : S.CONTEXT) : S.SOLVER with type t = C.t
+module Make (C : S.CONTEXT) : sig
+  include S.SOLVER with type t = C.t
+
+  module Input : sig
+    include Zeroinstall_solver.S.SOLVER_INPUT with type rejection = C.rejection
+  end
+
+  module Solver : sig
+    module Output : Zeroinstall_solver.S.SOLVER_RESULT with module Input = Input
+  end
+
+  module Diagnostics : sig
+    include module type of Zeroinstall_solver.Diagnostics(Solver.Output)
+  end
+
+  val diagnostics_rolemap : diagnostics -> Diagnostics.t
+end


### PR DESCRIPTION
As discussed in #30, I'm opening this PR as a draft so we can discuss the details and figure out the best solution. My first impression was that it would be simple to expose such a feature but it turns out quite a lot of changes are required.

Here I tried to preserve the module types definided in `S`, to avoid breaking user code that depends on those and therefore added everything I needed to the functor output signature directly. I'm happy to change that if you prefer.

The main problem I have here is that it seems that I need to expose quite a lot of internals to actually be able to get the `RoleMap.t`. I went for the quick and dirty solution here, just to see if I could interpret the result in `opam-monorepo` so I'm definitely willing to change all this as long as I can still properly interpret the rolemap in the end. Problem is, a lot of types and modules from `Zeroinstall_solver` functors are involved and trying to redefine the right subset here seems like a bad idea and something quite painful to achieve.

The current state of this PR allows me to interpret the rejections but the `impl` and `role` types, which I would also need are still abstract. Given how they are defined in `Model`, I don't think we should expose them. Exposing functions to convert them to `OpamPackage.t` or any relevant type in the opam library seems like the way to go but I'm not quite sure how to best do this. Do you have any suggestion on that front?

Please let me know if I missed something obvious that could simlify all this. Maybe the right solution here would to convert the 0install rolemap into something specific to opam-0install. There's quite a lot of indirection in both opam-0install and 0install and it's been quite the challenge to follow where to find the type and modules signatures. Converting to an opam-0install specific data structure could probably help solving this.