### PR TITLE
Add ?opam_version to `Dir_context.std_env`

### DIFF
--- a/lib/dir_context.ml
+++ b/lib/dir_context.ml
@@ -42,6 +42,7 @@ let dev = OpamPackage.Version.of_string "dev"
 let std_env
     ?(ocaml_native=true)
     ?sys_ocaml_version
+    ?opam_version
     ~arch ~os ~os_distribution ~os_family ~os_version
     () =
   function
@@ -50,7 +51,7 @@ let std_env
   | "os-distribution" -> Some (OpamTypes.S os_distribution)
   | "os-version" -> Some (OpamTypes.S os_version)
   | "os-family" -> Some (OpamTypes.S os_family)
-  | "opam-version"  -> Some (OpamVariable.string OpamVersion.(to_string current))
+  | "opam-version"  -> Some (OpamVariable.S (Option.value ~default:OpamVersion.(to_string current) opam_version))
   | "sys-ocaml-version" -> sys_ocaml_version |> Option.map (fun v -> OpamTypes.S v)
   | "ocaml:native" -> Some (OpamTypes.B ocaml_native)
   | "enable-ocaml-beta-repository" -> None      (* Fake variable? *)

--- a/lib/dir_context.mli
+++ b/lib/dir_context.mli
@@ -8,6 +8,7 @@ include S.CONTEXT
 val std_env :
   ?ocaml_native:bool ->
   ?sys_ocaml_version:string ->
+  ?opam_version:string ->
   arch:string ->
   os:string ->
   os_distribution:string ->
@@ -17,7 +18,9 @@ val std_env :
   (string -> OpamVariable.variable_contents option)
 (** [std_env ~arch ~os ~os_distribution ~os_family ~os_version] is an
     environment function that returns the given values for the standard opam
-    variables, and [None] for anything else. *)
+    variables, and [None] for anything else.
+    If [opam_version] is not provided, use the version of the linked opam
+    library. *)
 
 val create :
   ?prefer_oldest:bool ->


### PR DESCRIPTION
It defaults to the version of opam libraries, but in some cases (e.g. ocaml-ci) it is useful to inject a value that comes from an external opam process.
