### PR TITLE
opam-0install-cudf: Add support for the avoid-version flag

### DIFF
--- a/lib-cudf/model.ml
+++ b/lib-cudf/model.ml
@@ -66,7 +66,7 @@ module Make (Context : S.CONTEXT) = struct
     let compare a b =
       match a, b with
       | Real a, Real b -> String.compare a.name b.name
-      | Virtual (a, _), Virtual (b, _) -> compare (a : int) b
+      | Virtual (a, _), Virtual (b, _) -> Int.compare a b
       | Real _, Virtual _ -> -1
       | Virtual _, Real _ -> 1
   end
@@ -220,9 +220,9 @@ module Make (Context : S.CONTEXT) = struct
 
   let compare_version a b =
     match a, b with
-    | RealImpl a, RealImpl b -> compare (a.pkg.Cudf.version : int) b.pkg.Cudf.version
-    | VirtualImpl (ia, _), VirtualImpl (ib, _) -> compare (ia : int) ib
-    | Reject a, Reject b -> compare (snd a : int) (snd b)
+    | RealImpl a, RealImpl b -> Int.compare a.pkg.Cudf.version b.pkg.Cudf.version
+    | VirtualImpl (ia, _), VirtualImpl (ib, _) -> Int.compare ia ib
+    | Reject a, Reject b -> Int.compare (snd a) (snd b)
     | (RealImpl _ | Reject _ | VirtualImpl _ | Dummy),
       (RealImpl _ | Reject _ | VirtualImpl _ | Dummy)
       -> compare b a

--- a/lib-cudf/model.mli
+++ b/lib-cudf/model.mli
@@ -25,7 +25,7 @@ module Make (Context : S.CONTEXT) : sig
   (** [version impl] is the Opam package for [impl], if any.
       Virtual and dummy implementations return [None]. *)
 
-  val virtual_role : impl list -> Role.t
+  val virtual_role : context:Context.t -> impl list -> Role.t
   (** [virtual_role impls] is a virtual package name with candidates [impls].
       This is used if the user requests multiple packages on the command line
       (the single [impl] will also be virtual). *)

--- a/lib-cudf/opam_0install_cudf.ml
+++ b/lib-cudf/opam_0install_cudf.ml
@@ -17,9 +17,9 @@ module Context = struct
 
   let version_compare t pkg1 pkg2 =
     if t.prefer_oldest then
-      compare (pkg1.Cudf.version : int) pkg2.Cudf.version
+      Int.compare pkg1.Cudf.version pkg2.Cudf.version
     else
-      compare (pkg2.Cudf.version : int) pkg1.Cudf.version
+      Int.compare pkg2.Cudf.version pkg1.Cudf.version
 
   let candidates t name =
     let user_constraints = user_restrictions t name in

--- a/lib-cudf/opam_0install_cudf.ml
+++ b/lib-cudf/opam_0install_cudf.ml
@@ -1,3 +1,16 @@
+let tagged_with_avoid_version pkg =
+  List.exists (function
+    | "avoid-version", `Bool b -> b
+    | _ -> false
+  ) pkg.Cudf.pkg_extra
+
+let version_rev_compare ~prefer_oldest pkg1 pkg2 =
+  let rev cmp = if prefer_oldest then cmp else -cmp in
+  match tagged_with_avoid_version pkg1, tagged_with_avoid_version pkg2 with
+  | true, true | false, false -> rev (Int.compare pkg1.Cudf.version pkg2.Cudf.version)
+  | true, false -> 1
+  | false, true -> -1
+
 module Context = struct
   type rejection = UserConstraint of Cudf_types.vpkg
 
@@ -16,19 +29,14 @@ module Context = struct
         acc
     ) [] t.constraints
 
-  let version_compare t pkg1 pkg2 =
-    if t.prefer_oldest then
-      Int.compare pkg1.Cudf.version pkg2.Cudf.version
-    else
-      Int.compare pkg2.Cudf.version pkg1.Cudf.version
-
   let candidates t name =
     let user_constraints = user_restrictions t name in
     match Cudf.lookup_packages t.universe name with
     | [] ->
         [] (* Package not found *)
     | versions ->
-        List.fast_sort (version_compare t) versions (* Higher versions are preferred. *)
+        let prefer_oldest = t.prefer_oldest in
+        List.fast_sort (version_rev_compare ~prefer_oldest) versions (* Higher versions are preferred. *)
         |> List.map (fun pkg ->
           let rec check_constr = function
             | [] -> (pkg.Cudf.version, Ok pkg)

--- a/lib-cudf/s.ml
+++ b/lib-cudf/s.ml
@@ -16,4 +16,6 @@ module type CONTEXT = sig
   val user_restrictions : t -> Cudf_types.pkgname -> (Cudf_types.relop * Cudf_types.version) list
   (** [user_restrictions t pkg] is the user's constraint on [pkg], if any. This is just
       used for diagnostics; you still have to filter them out yourself in [candidates]. *)
+
+  val fresh_id : t -> int
 end


### PR DESCRIPTION
Take 2. Superseds https://github.com/ocaml-opam/opam-0install-solver/pull/35

For some reason I hadn’t thought of this very simple solution in #35...