### PR TITLE
Look up variables even if they refer to other packages

### DIFF
--- a/lib/switch_context.ml
+++ b/lib/switch_context.ml
@@ -16,6 +16,10 @@ let load t pkg =
 let user_restrictions t name =
   OpamPackage.Name.Map.find_opt name t.constraints
 
+let warn_unknown v =
+  let s = OpamVariable.Full.to_string v in
+  OpamConsole.warning "Unknown variable %S" s
+
 let env t pkg v =
   match List.mem v OpamPackageVar.predefined_depends_variables with
   | true -> None
@@ -26,7 +30,7 @@ let env t pkg v =
       match OpamVariable.Full.package v with
       | None -> (
         (* a local variable that is unknown *)
-        OpamConsole.warning "Unknown variable %S" (OpamVariable.Full.to_string v);
+        warn_unknown v;
         None)
       | Some pkg_name ->
         let installed_package = OpamPackage.Set.find_opt (fun package ->
@@ -41,7 +45,7 @@ let env t pkg v =
           let unscoped = OpamVariable.Full.(self (variable v)) in
           match OpamPackageVar.resolve_switch ~package t.st unscoped with
           | None ->
-            OpamConsole.warning "Unknown variable %S" (OpamVariable.Full.to_string v);
+            warn_unknown v;
             None
           | Some _ as resolved -> resolved
         )


### PR DESCRIPTION
`OpamPackageVar.resolve_switch` only looks up variables that are in the current package (and not specifying `~package` seems to make no difference), so add code to retrieve the name of the package from the variable, retrieve the package from the installed packages and look up the variable in that package.

This PR:

  1. Fixes the problem of not resolving variables that refer to other packages
  2. Silences the warning about unresolved variables if the variable refers to a package that is not installed.
  3. Keeps the warning if the variable is not referring to a package and undefined OR the package is installed and is missing the definition.

Closes #45.