### PR TITLE
Allow "Unknown variable" warnings to be surpressed

### DIFF
--- a/lib/switch_context.mli
+++ b/lib/switch_context.mli
@@ -2,6 +2,7 @@ include S.CONTEXT
 
 val create :
   ?prefer_oldest:bool ->
+  ?warn_on_unknown_variable:bool ->
   ?test:OpamPackage.Name.Set.t ->
   constraints:OpamFormula.version_constraint OpamTypes.name_map ->
   OpamStateTypes.unlocked OpamStateTypes.switch_state ->


### PR DESCRIPTION
When using the opam-0install library to solve dependencies the "Unknown variable" warnings can get in the way of other console output. This adds an optional argument which enables printing this warning (defaulting to `true`).