### PR TITLE
Use domain-local ref when generating IDs

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@ This package uses 0install's solver algorithm with opam packages.
   (fmt (>= 0.8.7))
   (cmdliner (>= 1.1.0))
   (opam-state (>= 2.1.0~rc))
-  (ocaml (>= 4.10.0))
+  (ocaml (>= 5.0.0))
   0install-solver
   (opam-file-format (>= 2.1.1))
   (opam-client :with-test)
@@ -54,5 +54,5 @@ the CUDF interface.
 ")
  (depends
   cudf
-  (ocaml (>= 4.10.0))
+  (ocaml (>= 5.0.0))
   0install-solver))

--- a/lib-cudf/model.ml
+++ b/lib-cudf/model.ml
@@ -1,5 +1,7 @@
 (* Note: changes to this file may require similar changes to lib/model.ml *)
 
+let id_key = Domain.DLS.new_key (fun () -> ref 0)
+
 let fop : Cudf_types.relop -> int -> int -> bool = function
   | `Eq -> (=)
   | `Neq -> (<>)
@@ -73,11 +75,10 @@ module Make (Context : S.CONTEXT) = struct
 
   let role context name = Real { context; name }
 
-  let fresh_id =
-    let i = ref 0 in
-    fun () ->
-      incr i;
-      !i
+  let fresh_id () =
+    let i = Domain.DLS.get id_key in
+    incr i;
+    !i
 
   let virtual_impl ~context ~depends () =
     let depends = depends |> List.map (fun (name, importance) ->

--- a/lib/model.ml
+++ b/lib/model.ml
@@ -1,5 +1,7 @@
 (* Note: changes to this file may require similar changes to lib-cudf/model.ml *)
 
+let id_key = Domain.DLS.new_key (fun () -> ref 0)
+
 module Make (Context : S.CONTEXT) = struct
   (* Note: [OpamFormula.neg] doesn't work in the [Empty] case, so we just
      record whether to negate the result here. *)
@@ -64,11 +66,10 @@ module Make (Context : S.CONTEXT) = struct
 
   let role context name = Real { context; name }
 
-  let fresh_id =
-    let i = ref 0 in
-    fun () ->
-      incr i;
-      !i
+  let fresh_id () =
+    let i = Domain.DLS.get id_key in
+    incr i;
+    !i
 
   let virtual_impl ~context ~depends () =
     let depends = depends |> List.map (fun name ->

--- a/opam-0install-cudf.opam
+++ b/opam-0install-cudf.opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
 depends: [
   "dune" {>= "2.7"}
   "cudf"
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "5.0.0"}
   "0install-solver"
   "odoc" {with-doc}
 ]

--- a/opam-0install.opam
+++ b/opam-0install.opam
@@ -24,7 +24,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "cmdliner" {>= "1.1.0"}
   "opam-state" {>= "2.1.0~rc"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "5.0.0"}
   "0install-solver"
   "opam-file-format" {>= "2.1.1"}
   "opam-client" {with-test}


### PR DESCRIPTION
We use unique IDs for sorting purposes. Previously these were generated using a global `ref`, but that is a race when multiple domains are used (spotted by ocaml-tsan).