### PR TITLE
Add monadic interface to solver

### DIFF
--- a/lib/dir_context.ml
+++ b/lib/dir_context.ml
@@ -1,124 +1,126 @@
-type rejection =
-  | UserConstraint of OpamFormula.atom
-  | Unavailable
+module Dir_context (M : S.MONAD) (C: S.CONTEXT) = struct
+  type rejection =
+    | UserConstraint of OpamFormula.atom
+    | Unavailable
 
-let ( / ) = Filename.concat
+  let ( / ) = Filename.concat
 
-let with_dir path fn =
-  let ch = Unix.opendir path in
-  Fun.protect ~finally:(fun () -> Unix.closedir ch)
-    (fun () -> fn ch)
+  let with_dir path fn =
+    let ch = Unix.opendir path in
+    Fun.protect ~finally:(fun () -> Unix.closedir ch)
+      (fun () -> fn ch)
 
-let list_dir path =
-  let rec aux acc ch =
-    match Unix.readdir ch with
-    | name -> aux (name :: acc) ch
-    | exception End_of_file -> acc
-  in
-  with_dir path (aux [])
+  let list_dir path =
+    let rec aux acc ch =
+      match Unix.readdir ch with
+      | name -> aux (name :: acc) ch
+      | exception End_of_file -> acc
+    in
+    with_dir path (aux [])
 
-type t = {
-  env : string -> OpamVariable.variable_contents option;
-  packages_dir : string;
-  pins : (OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t;
-  constraints : OpamFormula.version_constraint OpamTypes.name_map;    (* User-provided constraints *)
-  test : OpamPackage.Name.Set.t;
-  prefer_oldest : bool;
-}
+  type t = {
+    env : string -> OpamVariable.variable_contents option;
+    packages_dir : string;
+    pins : (OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t;
+    constraints : OpamFormula.version_constraint OpamTypes.name_map;    (* User-provided constraints *)
+    test : OpamPackage.Name.Set.t;
+    prefer_oldest : bool;
+  }
 
-let load t pkg =
-  let { OpamPackage.name; version = _ } = pkg in
-  match OpamPackage.Name.Map.find_opt name t.pins with
-  | Some (_, opam) -> opam
-  | None ->
-    let opam_path = t.packages_dir / OpamPackage.Name.to_string name / OpamPackage.to_string pkg / "opam" in
-    OpamFile.OPAM.read (OpamFile.make (OpamFilename.raw opam_path))
+  let load t pkg =
+    let { OpamPackage.name; version = _ } = pkg in
+    match OpamPackage.Name.Map.find_opt name t.pins with
+    | Some (_, opam) -> opam
+    | None ->
+      let opam_path = t.packages_dir / OpamPackage.Name.to_string name / OpamPackage.to_string pkg / "opam" in
+      OpamFile.OPAM.read (OpamFile.make (OpamFilename.raw opam_path))
 
-let user_restrictions t name =
-  OpamPackage.Name.Map.find_opt name t.constraints
+  let user_restrictions t name =
+    OpamPackage.Name.Map.find_opt name t.constraints
 
-let dev = OpamPackage.Version.of_string "dev"
+  let dev = OpamPackage.Version.of_string "dev"
 
-let std_env
-    ?(ocaml_native=true)
-    ?sys_ocaml_version
-    ?opam_version
-    ~arch ~os ~os_distribution ~os_family ~os_version
-    () =
-  function
-  | "arch" -> Some (OpamTypes.S arch)
-  | "os" -> Some (OpamTypes.S os)
-  | "os-distribution" -> Some (OpamTypes.S os_distribution)
-  | "os-version" -> Some (OpamTypes.S os_version)
-  | "os-family" -> Some (OpamTypes.S os_family)
-  | "opam-version"  -> Some (OpamVariable.S (Option.value ~default:OpamVersion.(to_string current) opam_version))
-  | "sys-ocaml-version" -> sys_ocaml_version |> Option.map (fun v -> OpamTypes.S v)
-  | "ocaml:native" -> Some (OpamTypes.B ocaml_native)
-  | "enable-ocaml-beta-repository" -> None      (* Fake variable? *)
-  | v ->
-    OpamConsole.warning "Unknown variable %S" v;
-    None
+  let std_env
+      ?(ocaml_native=true)
+      ?sys_ocaml_version
+      ?opam_version
+      ~arch ~os ~os_distribution ~os_family ~os_version
+      () =
+    function
+    | "arch" -> Some (OpamTypes.S arch)
+    | "os" -> Some (OpamTypes.S os)
+    | "os-distribution" -> Some (OpamTypes.S os_distribution)
+    | "os-version" -> Some (OpamTypes.S os_version)
+    | "os-family" -> Some (OpamTypes.S os_family)
+    | "opam-version"  -> Some (OpamVariable.S (Option.value ~default:OpamVersion.(to_string current) opam_version))
+    | "sys-ocaml-version" -> sys_ocaml_version |> Option.map (fun v -> OpamTypes.S v)
+    | "ocaml:native" -> Some (OpamTypes.B ocaml_native)
+    | "enable-ocaml-beta-repository" -> None      (* Fake variable? *)
+    | v ->
+      OpamConsole.warning "Unknown variable %S" v;
+      None
 
-let env t pkg v =
-  if List.mem v OpamPackageVar.predefined_depends_variables then None
-  else match OpamVariable.Full.to_string v with
-    | "version" -> Some (OpamTypes.S (OpamPackage.Version.to_string (OpamPackage.version pkg)))
-    | x -> t.env x
+  let env t pkg v =
+    if List.mem v OpamPackageVar.predefined_depends_variables then None
+    else match OpamVariable.Full.to_string v with
+      | "version" -> Some (OpamTypes.S (OpamPackage.Version.to_string (OpamPackage.version pkg)))
+      | x -> t.env x
 
-let filter_deps t pkg f =
-  let dev = OpamPackage.Version.compare (OpamPackage.version pkg) dev = 0 in
-  let test = OpamPackage.Name.Set.mem (OpamPackage.name pkg) t.test in
-  f
-  |> OpamFilter.partial_filter_formula (env t pkg)
-  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev ~default:false
+  let filter_deps t pkg f =
+    let dev = OpamPackage.Version.compare (OpamPackage.version pkg) dev = 0 in
+    let test = OpamPackage.Name.Set.mem (OpamPackage.name pkg) t.test in
+    f
+    |> OpamFilter.partial_filter_formula (env t pkg)
+    |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev ~default:false
 
-let version_compare t v1 v2 =
-  if t.prefer_oldest then
-    OpamPackage.Version.compare v1 v2
-  else
-    OpamPackage.Version.compare v2 v1
+  let version_compare t v1 v2 =
+    if t.prefer_oldest then
+      OpamPackage.Version.compare v1 v2
+    else
+      OpamPackage.Version.compare v2 v1
 
-let candidates t name =
-  match OpamPackage.Name.Map.find_opt name t.pins with
-  | Some (version, opam) -> [version, Ok opam]
-  | None ->
-    let versions_dir = t.packages_dir / OpamPackage.Name.to_string name in
-    match list_dir versions_dir with
-    | versions ->
-      let user_constraints = user_restrictions t name in
-      versions
-      |> List.filter_map (fun dir ->
-          match OpamPackage.of_string_opt dir with
-          | Some pkg when Sys.file_exists (versions_dir / dir / "opam") -> Some (OpamPackage.version pkg)
-          | _ -> None
-        )
-      |> List.sort (version_compare t)
-      |> List.map (fun v ->
-          match user_constraints with
-          | Some test when not (OpamFormula.check_version_formula (OpamFormula.Atom test) v) ->
-            v, Error (UserConstraint (name, Some test))
-          | _ ->
-            let pkg = OpamPackage.create name v in
-            let opam = load t pkg in
-            let available = OpamFile.OPAM.available opam in
-            match OpamFilter.eval ~default:(B false) (env t pkg) available with
-            | B true -> v, Ok opam
-            | B false -> v, Error Unavailable
+  let candidates t name =
+    match OpamPackage.Name.Map.find_opt name t.pins with
+    | Some (version, opam) -> [version, Ok opam]
+    | None ->
+      let versions_dir = t.packages_dir / OpamPackage.Name.to_string name in
+      match list_dir versions_dir with
+      | versions ->
+        let user_constraints = user_restrictions t name in
+        versions
+        |> List.filter_map (fun dir ->
+            match OpamPackage.of_string_opt dir with
+            | Some pkg when Sys.file_exists (versions_dir / dir / "opam") -> Some (OpamPackage.version pkg)
+            | _ -> None
+          )
+        |> List.sort (version_compare t)
+        |> List.map (fun v ->
+            match user_constraints with
+            | Some test when not (OpamFormula.check_version_formula (OpamFormula.Atom test) v) ->
+              v, Error (UserConstraint (name, Some test))
             | _ ->
-              OpamConsole.error "Available expression not a boolean: %s" (OpamFilter.to_string available);
-              v, Error Unavailable
-        )
-    | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
-      OpamConsole.log "opam-0install" "Package %S not found!" (OpamPackage.Name.to_string name);
-      []
+              let pkg = OpamPackage.create name v in
+              let opam = load t pkg in
+              let available = OpamFile.OPAM.available opam in
+              match OpamFilter.eval ~default:(B false) (env t pkg) available with
+              | B true -> v, Ok opam
+              | B false -> v, Error Unavailable
+              | _ ->
+                OpamConsole.error "Available expression not a boolean: %s" (OpamFilter.to_string available);
+                v, Error Unavailable
+          )
+      | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+        OpamConsole.log "opam-0install" "Package %S not found!" (OpamPackage.Name.to_string name);
+        []
 
-let pp_rejection f = function
-  | UserConstraint x -> Fmt.pf f "Rejected by user-specified constraint %s" (OpamFormula.string_of_atom x)
-  | Unavailable -> Fmt.string f "Availability condition not satisfied"
+  let pp_rejection f = function
+    | UserConstraint x -> Fmt.pf f "Rejected by user-specified constraint %s" (OpamFormula.string_of_atom x)
+    | Unavailable -> Fmt.string f "Availability condition not satisfied"
 
-let create
-      ?(prefer_oldest=false)
-      ?(test=OpamPackage.Name.Set.empty)
-      ?(pins=OpamPackage.Name.Map.empty)
-      ~constraints ~env packages_dir =
-  { env; packages_dir; pins; constraints; test; prefer_oldest }
+  let create
+        ?(prefer_oldest=false)
+        ?(test=OpamPackage.Name.Set.empty)
+        ?(pins=OpamPackage.Name.Map.empty)
+        ~constraints ~env packages_dir =
+    { env; packages_dir; pins; constraints; test; prefer_oldest }
+end

--- a/lib/dir_context.mli
+++ b/lib/dir_context.mli
@@ -3,42 +3,44 @@
     It also does not get any opam variables from the environment - instead, the caller
     must provide them explicitly. *)
 
-include S.CONTEXT
+module Dir_context : functor (M: S.MONAD) -> functor (C: S.CONTEXT) -> sig
+  include module type of C(M)
 
-val std_env :
-  ?ocaml_native:bool ->
-  ?sys_ocaml_version:string ->
-  ?opam_version:string ->
-  arch:string ->
-  os:string ->
-  os_distribution:string ->
-  os_family:string ->
-  os_version:string ->
-  unit ->
-  (string -> OpamVariable.variable_contents option)
-(** [std_env ~arch ~os ~os_distribution ~os_family ~os_version] is an
-    environment function that returns the given values for the standard opam
-    variables, and [None] for anything else.
-    If [opam_version] is not provided, use the version of the linked opam
-    library. *)
+  val std_env :
+    ?ocaml_native:bool ->
+    ?sys_ocaml_version:string ->
+    ?opam_version:string ->
+    arch:string ->
+    os:string ->
+    os_distribution:string ->
+    os_family:string ->
+    os_version:string ->
+    unit ->
+    (string -> OpamVariable.variable_contents option)
+  (** [std_env ~arch ~os ~os_distribution ~os_family ~os_version] is an
+      environment function that returns the given values for the standard opam
+      variables, and [None] for anything else.
+      If [opam_version] is not provided, use the version of the linked opam
+      library. *)
 
-val create :
-  ?prefer_oldest:bool ->
-  ?test:OpamPackage.Name.Set.t ->
-  ?pins:(OpamTypes.version * OpamFile.OPAM.t) OpamTypes.name_map ->
-  constraints:OpamFormula.version_constraint OpamTypes.name_map ->
-  env:(string -> OpamVariable.variable_contents option) ->
-  string ->
-  t
-(** [create ~constraints ~env packages_dir] is a solver that gets candidates
-    from [packages_dir], filtering them using [constraints]. [packages_dir] contains
-    one sub-directory for each package name, each with subdirectories for each version, in
-    the same format used by opam-repository.
-    @param test Packages for which we should include "with-test" dependencies.
-    @param pins Packages in this map have only the given candidate version and opam file.
-    @param env Maps opam variable names to values ({!std_env} may be useful here).
-               "version" and the [OpamPackageVar.predefined_depends_variables] are handled automatically.
-    @param prefer_oldest if [true] the solver is set to return the least
-    up-to-date version of each package, if a solution exists. This is [false] by
-    default.
-    @before 0.4 the [prefer_oldest] parameter did not exist. *)
+  val create :
+    ?prefer_oldest:bool ->
+    ?test:OpamPackage.Name.Set.t ->
+    ?pins:(OpamTypes.version * OpamFile.OPAM.t) OpamTypes.name_map ->
+    constraints:OpamFormula.version_constraint OpamTypes.name_map ->
+    env:(string -> OpamVariable.variable_contents option) ->
+    string ->
+    t
+  (** [create ~constraints ~env packages_dir] is a solver that gets candidates
+      from [packages_dir], filtering them using [constraints]. [packages_dir] contains
+      one sub-directory for each package name, each with subdirectories for each version, in
+      the same format used by opam-repository.
+      @param test Packages for which we should include "with-test" dependencies.
+      @param pins Packages in this map have only the given candidate version and opam file.
+      @param env Maps opam variable names to values ({!std_env} may be useful here).
+                 "version" and the [OpamPackageVar.predefined_depends_variables] are handled automatically.
+      @param prefer_oldest if [true] the solver is set to return the least
+      up-to-date version of each package, if a solution exists. This is [false] by
+      default.
+      @before 0.4 the [prefer_oldest] parameter did not exist. *)
+end

--- a/lib/model.mli
+++ b/lib/model.mli
@@ -14,10 +14,11 @@
     become a dependency on a virtual package which has each choice as an
     implementation. *)
 
-module Make (Context : S.CONTEXT) : sig
-  include Zeroinstall_solver.S.SOLVER_INPUT with type rejection = Context.rejection
+module Make (M : S.MONAD) (Context : S.CONTEXT) : sig
 
-  val role : Context.t -> OpamPackage.Name.t -> Role.t
+  include Zeroinstall_solver.S.SOLVER_INPUT with type rejection = Context(M).rejection
+
+  val role : Context(M).t -> OpamPackage.Name.t -> Role.t
 
   val version : impl -> OpamPackage.t option
   (** [version impl] is the Opam package for [impl], if any.
@@ -28,7 +29,7 @@ module Make (Context : S.CONTEXT) : sig
       This is used if the user requests multiple packages on the command line
       (the single [impl] will also be virtual). *)
 
-  val virtual_impl : context:Context.t -> depends:OpamPackage.Name.t list -> unit -> impl
+  val virtual_impl : context:Context(M).t -> depends:OpamPackage.Name.t list -> unit -> impl
   (** [virtual_impl ~context ~depends] is a virtual package which just depends
       on [depends]. This is used if the user requests multiple packages on the
       command line - each requested package becomes a dependency of the virtual

--- a/lib/solver.mli
+++ b/lib/solver.mli
@@ -1,11 +1,12 @@
-module Make (C : S.CONTEXT) : sig
-  module Input : Zeroinstall_solver.S.SOLVER_INPUT with type rejection = C.rejection
+module Make (M : S.MONAD) (C : S.CONTEXT) : sig
+  module Input : Zeroinstall_solver.S.SOLVER_INPUT with type rejection = C(M).rejection
 
   module Solver : sig
     module Output : Zeroinstall_solver.S.SOLVER_RESULT with module Input = Input
   end
 
-  include S.SOLVER with type t = C.t and type selections = Solver.Output.t
+  (* include S.SOLVER with type t = C.t and type selections = Solver.Output.t *)
+  include module type of S.SOLVER(M)
 
   module Diagnostics : sig
     include module type of Zeroinstall_solver.Diagnostics(Solver.Output)

--- a/lib/switch_context.ml
+++ b/lib/switch_context.ml
@@ -1,63 +1,67 @@
-type rejection = UserConstraint of OpamFormula.atom
+module Switch_context (M : S.MONAD) (C: S.CONTEXT) = struct
 
-type t = {
-  st : OpamStateTypes.unlocked OpamStateTypes.switch_state;           (* To load the opam files *)
-  pkgs : OpamTypes.version_set OpamTypes.name_map;                    (* All available versions *)
-  constraints : OpamFormula.version_constraint OpamTypes.name_map;    (* User-provided constraints *)
-  test : OpamPackage.Name.Set.t;
-  prefer_oldest : bool;
-}
+  type rejection = UserConstraint of OpamFormula.atom
 
-let load t pkg =
-  try OpamSwitchState.opam t.st pkg
-  with Not_found ->
-    failwith (Format.asprintf "Package %S not found!" (OpamPackage.to_string pkg))
+  type t = {
+    st : OpamStateTypes.unlocked OpamStateTypes.switch_state;           (* To load the opam files *)
+    pkgs : OpamTypes.version_set OpamTypes.name_map;                    (* All available versions *)
+    constraints : OpamFormula.version_constraint OpamTypes.name_map;    (* User-provided constraints *)
+    test : OpamPackage.Name.Set.t;
+    prefer_oldest : bool;
+  }
 
-let user_restrictions t name =
-  OpamPackage.Name.Map.find_opt name t.constraints
+  let load t pkg =
+    try OpamSwitchState.opam t.st pkg
+    with Not_found ->
+      failwith (Format.asprintf "Package %S not found!" (OpamPackage.to_string pkg))
 
-let env t pkg v =
-  if List.mem v OpamPackageVar.predefined_depends_variables then None
-  else (
-    let r = OpamPackageVar.resolve_switch ~package:pkg t.st v in
-    if r = None then OpamConsole.warning "Unknown variable %S" (OpamVariable.Full.to_string v);
-    r
-  )
+  let user_restrictions t name =
+    OpamPackage.Name.Map.find_opt name t.constraints
 
-let filter_deps t pkg f =
-  let test = OpamPackage.Name.Set.mem (OpamPackage.name pkg) t.test in
-  f
-  |> OpamFilter.partial_filter_formula (env t pkg)
-  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev:false ~default:false
+  let env t pkg v =
+    if List.mem v OpamPackageVar.predefined_depends_variables then None
+    else (
+      let r = OpamPackageVar.resolve_switch ~package:pkg t.st v in
+      if r = None then OpamConsole.warning "Unknown variable %S" (OpamVariable.Full.to_string v);
+      r
+    )
 
-let sort_versions t versions =
-  if t.prefer_oldest then
-    versions
-  else
-    List.rev versions
+  let filter_deps t pkg f =
+    let test = OpamPackage.Name.Set.mem (OpamPackage.name pkg) t.test in
+    f
+    |> OpamFilter.partial_filter_formula (env t pkg)
+    |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev:false ~default:false
 
-let candidates t name =
-  let user_constraints = user_restrictions t name in
-  match OpamPackage.Name.Map.find_opt name t.pkgs with
-  | Some versions ->
-    OpamPackage.Version.Set.elements versions
-    |> sort_versions t       (* Higher versions are preferred. *)
-    |> List.map (fun v ->
-        match user_constraints with
-        | Some test when not (OpamFormula.check_version_formula (OpamFormula.Atom test) v) ->
-          v, Error (UserConstraint (name, Some test))
-        | _ ->
-          let opam = load t (OpamPackage.create name v) in
-          (* Note: [OpamStateTypes.available_packages] filters out unavailable packages for us. *)
-          v, Ok opam
-      )
-  | None ->
-    OpamConsole.log "opam-0install" "Package %S not found!" (OpamPackage.Name.to_string name);
-    []
+  let sort_versions t versions =
+    if t.prefer_oldest then
+      versions
+    else
+      List.rev versions
 
-let pp_rejection f = function
-  | UserConstraint x -> Fmt.pf f "Rejected by user-specified constraint %s" (OpamFormula.string_of_atom x)
+  let candidates t name =
+    let user_constraints = user_restrictions t name in
+    match OpamPackage.Name.Map.find_opt name t.pkgs with
+    | Some versions ->
+      OpamPackage.Version.Set.elements versions
+      |> sort_versions t       (* Higher versions are preferred. *)
+      |> List.map (fun v ->
+          match user_constraints with
+          | Some test when not (OpamFormula.check_version_formula (OpamFormula.Atom test) v) ->
+            v, Error (UserConstraint (name, Some test))
+          | _ ->
+            let opam = load t (OpamPackage.create name v) in
+            (* Note: [OpamStateTypes.available_packages] filters out unavailable packages for us. *)
+            v, Ok opam
+        )
+    | None ->
+      OpamConsole.log "opam-0install" "Package %S not found!" (OpamPackage.Name.to_string name);
+      []
 
-let create ?(prefer_oldest=false) ?(test=OpamPackage.Name.Set.empty) ~constraints st =
-  let pkgs = Lazy.force st.OpamStateTypes.available_packages |> OpamPackage.to_map in
-  { st; pkgs; constraints; test; prefer_oldest }
+  let pp_rejection f = function
+    | UserConstraint x -> Fmt.pf f "Rejected by user-specified constraint %s" (OpamFormula.string_of_atom x)
+
+  let create ?(prefer_oldest=false) ?(test=OpamPackage.Name.Set.empty) ~constraints st =
+    let pkgs = Lazy.force st.OpamStateTypes.available_packages |> OpamPackage.to_map in
+    { st; pkgs; constraints; test; prefer_oldest }
+
+end

--- a/lib/switch_context.mli
+++ b/lib/switch_context.mli
@@ -1,17 +1,19 @@
-include S.CONTEXT
+module Switch_context : functor (M : S.MONAD) -> functor (C : S.CONTEXT) -> sig
+  include module type of C(M)
 
-val create :
-  ?prefer_oldest:bool ->
-  ?test:OpamPackage.Name.Set.t ->
-  constraints:OpamFormula.version_constraint OpamTypes.name_map ->
-  OpamStateTypes.unlocked OpamStateTypes.switch_state ->
-  t
-(** [create ~constraints switch] is a solver that gets candidates from [switch], filtering them
-    using [constraints].
+  val create :
+    ?prefer_oldest:bool ->
+    ?test:OpamPackage.Name.Set.t ->
+    constraints:OpamFormula.version_constraint OpamTypes.name_map ->
+    OpamStateTypes.unlocked OpamStateTypes.switch_state ->
+    t
+  (** [create ~constraints switch] is a solver that gets candidates from [switch], filtering them
+      using [constraints].
 
-    @param test Packages for which we should include "with-test" dependencies.
+      @param test Packages for which we should include "with-test" dependencies.
 
-    @param prefer_oldest if [true] the solver is set to return the least
-    up-to-date version of each package, if a solution exists. This is [false] by
-    default.
-    @before 0.4 the [prefer_oldest] parameter did not exist. *)
+      @param prefer_oldest if [true] the solver is set to return the least
+      up-to-date version of each package, if a solution exists. This is [false] by
+      default.
+      @before 0.4 the [prefer_oldest] parameter did not exist. *)
+end


### PR DESCRIPTION
This allows to plug in concurrency monads like Lwt, Async or Dune's Fiber into the solver and have the callbacks return the concurrency monad.

Currently work in progress, needs support code in 0install-solver as well.