### PR TITLE
Avoid non-domain-safe global counter

### DIFF
--- a/lib/model.mli
+++ b/lib/model.mli
@@ -29,7 +29,7 @@ module Make (Context : S.CONTEXT) : sig
       (the single [impl] will also be virtual). *)
 
   val virtual_impl : context:Context.t -> depends:OpamPackage.Name.t list -> unit -> impl
-  (** [virtual_impl ~context ~depends] is a virtual package which just depends
+  (** [virtual_impl ~context ~depends ()] is a virtual package which just depends
       on [depends]. This is used if the user requests multiple packages on the
       command line - each requested package becomes a dependency of the virtual
       implementation. *)


### PR DESCRIPTION
Roles need to have unique IDs so they can be used as map keys. This was done for virtual roles by incrementing a global ref-cell, but this isn't safe when using multiple domains. Instead, use an empty object.

Virtual implementations (used for or-patterns in dependencies) also used this global counter to get an integer used for sorting. This is only used when reporting diagnostics. We now use a local counter for this.

This should fix the tsan warning, and might be slightly faster as different cores don't need to share the same counter.

This is an alternative to #51 that doesn't require OCaml 5.