### PR TITLE
Add `lock_kind` argument to `OpamStateConfig.load_defaults`

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -7,7 +7,7 @@ let select verbose with_test prefer_oldest graph spec =
     let t0 = Unix.gettimeofday () in
     let root = OpamStateConfig.opamroot () in
     OpamFormatConfig.init ();
-    ignore (OpamStateConfig.load_defaults root);
+    ignore (OpamStateConfig.load_defaults ~lock_kind:`Lock_read root);
     OpamCoreConfig.init ();
     OpamStateConfig.init ();
     OpamGlobalState.with_ `Lock_none @@ fun gt ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -148,7 +148,7 @@ let () =
   let t0 = Unix.gettimeofday () in
   let root = OpamStateConfig.opamroot () in
   OpamFormatConfig.init ();
-  ignore (OpamStateConfig.load_defaults root);
+  ignore (OpamStateConfig.load_defaults ~lock_kind:`Lock_read root);
   OpamCoreConfig.init ();
   OpamStateConfig.init ();
   OpamClientConfig.opam_init ();


### PR DESCRIPTION
opam-state.2.4.0 makes it mandatory: https://github.com/ocaml/opam/pull/5488.

Not having it causes a warning while developing:
```
File "bin/main.ml", line 10, characters 11-48:
10 |     ignore (OpamStateConfig.load_defaults  root);
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error (warning 5 [ignored-partial-application]): this function application is partial,
maybe some arguments are missing.
```

When installed from opam-repository, dune disables warnings, so opam-0install installs fine, but just doesn't work:
```
[ERROR] No switch is currently set. Please use 'opam switch' to set or install a switch
opam-0install: internal error, uncaught exception:
               OpamStd.OpamSys.Exit(50)
```